### PR TITLE
Extra field

### DIFF
--- a/ExtraField.py
+++ b/ExtraField.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Dec  5 10:39:08 2018
+
+@author: mmtobias
+"""
+
+import json
+import requests
+import urllib.request
+from math import ceil
+
+userID = ''
+collectionID = ''
+apiKey = ''
+
+def api_get(userID, collectionID, apiKey, limit=100, start=0):
+    api_url = 'https://api.zotero.org/users/%s/collections/%s/items?key=%s&limit=%s&start=%s&itemType=-attachment || note' % (userID, collectionID, apiKey, limit, start)
+    #QgsMessageLog.logMessage(api_url, 'LiteratureMapper', Qgis.Info)
+    zotero_response = requests.get(api_url)
+    return zotero_response
+
+def parse_zotero(zotero_response):
+    #encoded_data = json.dumps(zotero_response.content)
+	  #encoded_data = json.dumps(data.content)
+    #parsed_data = json.loads(encoded_data)
+    parsed_data = json.loads(zotero_response.content.decode('utf-8'))
+    return parsed_data
+
+
+data = api_get(userID, collectionID, apiKey)
+data_json = parse_zotero(data)
+
+
+
+# accessing the Extra field:
+# data_json[2]['data']['extra']
+
+
+# Text to work with as an example of what this should look like.
+text_extra = 'Notes about a citation. Some other stuff that is too important to erase. <geojson>{"type": "Point", "coordinates": [-121.943352010208, 36.5996662302192]}</geojson> Plus someone put something after this because they could.'
+
+# STUFF THAT DIDN'T WORK BUT MIGHT HELP LATER:
+# split the extra string 
+#text_extra_parts = text_extra.split("<geojson>")
+#remove the end tag
+#test_extra_parts = text_extra[1].replace("/geojson>", "")
+#test_extra_parts = text_extra[1].strip("/geojson>")
+#json_string = text_extra_parts[1]
+
+# Get the geojson string from the extra field
+geojson_str = text_extra[text_extra.find("<geojson>")+9:text_extra.find("</geojson>")]
+
+
+# How do we update the string and then insert it into the extra string?
+
+#get the stuff in front of the <geojson> and after </geojson>, then concatenate them with the new spatial string?
+before_geojson = text_extra[0 : text_extra.find("<geojson>")]
+after_geojson = text_extra[text_extra.find("</geojson>")+10:]
+
+# Put it back together
+# -----> saveZotero() function's extraString gets what we have here in geojson_str
+
+new_extra = before_geojson + "<geojson>" + geojson_str + "</geojson>" + after_geojson
+
+
+
+
+
+
+
+

--- a/literature_mapper.py
+++ b/literature_mapper.py
@@ -239,13 +239,22 @@ class LiteratureMapper:
         for row in rows:
             #get the itemID(zotero key) and geometry cells from the table - itemAt(x,y)
             itemKey = self.dlgTable.tableWidget_Zotero.item(row, 0).text()
-            extraString = self.dlgTable.tableWidget_Zotero.item(row, 4).text()
-            QgsMessageLog.logMessage("row: %s  itemKey: %s  extraString: %s" % (row, itemKey, extraString), 'LiteratureMapper', Qgis.Info)
             
             request_url = 'https://api.zotero.org/users/%s/items/%s' % (self.userID, itemKey)
             item_request = requests.get(request_url)
             QgsMessageLog.logMessage("Item Request Response: %s" % item_request.status_code, 'LiteratureMapper', Qgis.Info)
             item_json = json.load(urllib.request.urlopen(request_url))
+            
+            #Put the extra string back together with the new coordinates
+            tablegeom = self.dlgTable.tableWidget_Zotero.item(row, 4).text()
+            extraZotero = item_json['data']['extra']
+            before_geojson = extraZotero[0 : extraZotero.find("<geojson>")]
+            after_geojson = extraZotero[extraZotero.find("</geojson>")+10:]
+            extraString = '%s "<geojson>" %s "</geojson>" %s' % (before_geojson, tablegeom, after_geojson) #build the new extraString here
+            
+            QgsMessageLog.logMessage("row: %s  itemKey: %s  extraString: %s" % (row, itemKey, extraString), 'LiteratureMapper', Qgis.Info)
+            
+            
             ####### saving Extra field
             item_json['data']['extra'] = extraString
             item_json=json.dumps(item_json)
@@ -494,16 +503,30 @@ class LiteratureMapper:
                     ########## Putting the Extra field into the table
                     # pre-populate the table with anything already in the Extra field
                     if 'extra' in record['data']:
-                        extra = QTableWidgetItem(record['data']['extra'])
+                        #extra = QTableWidgetItem(record['data']['extra'])
                         
-                        extra_str = record['data']['extra']
+                        extra_zotero = record['data']['extra']
                         
                         #example of how to pull out the geojson string from a messy Extra field:
                         #geojson_str = text_extra[text_extra.find("<geojson>")+9:text_extra.find("</geojson>")]
-                        extra_str = extra_str[extra_str.find("<geojson>")+9:extra_str.find("</geojson>")]
+                        
+                     
+                        
+                        
+                        if "<geojson>" in extra_zotero:
+                            extra_str = extra_zotero[extra_zotero.find("<geojson>")+9:extra_zotero.find("</geojson>")]
+                            #before_geojson = extra_zotero[0 : extra_zotero.find("<geojson>")]
+                            #after_geojson = extra_zotero[extra_zotero.find("</geojson>")+10:]
+                        elif "{\"type\":" in extra_zotero:
+                            extra_str = extra_zotero[extra_zotero.find("{"):extra_zotero.find("}")]
+                        else: extra_str = ""
+                        
+                        extra = QTableWidgetItem(extra_str)
+                        
                         
                         #prints the extra string to the log
                         QgsMessageLog.logMessage("Extra String: %s" % extra_str, 'LiteratureMapper', Qgis.Info)
+                        
                         
                         
                         check_point = '"type": "Point"'

--- a/literature_mapper.py
+++ b/literature_mapper.py
@@ -246,6 +246,7 @@ class LiteratureMapper:
             item_request = requests.get(request_url)
             QgsMessageLog.logMessage("Item Request Response: %s" % item_request.status_code, 'LiteratureMapper', Qgis.Info)
             item_json = json.load(urllib.request.urlopen(request_url))
+            ####### saving Extra field
             item_json['data']['extra'] = extraString
             item_json=json.dumps(item_json)
             put_request = requests.put(request_url, data=item_json, headers={'Authorization': 'Bearer %s' % (self.apiKey), 'Content-Type': 'application/json'})
@@ -490,12 +491,21 @@ class LiteratureMapper:
                     self.dlgTable.tableWidget_Zotero.setItem(i, 3, title)
                     title_str = record['data']['title']
                     
+                    ########## Putting the Extra field into the table
                     # pre-populate the table with anything already in the Extra field
                     if 'extra' in record['data']:
                         extra = QTableWidgetItem(record['data']['extra'])
                         
                         extra_str = record['data']['extra']
+                        
+                        #example of how to pull out the geojson string from a messy Extra field:
+                        #geojson_str = text_extra[text_extra.find("<geojson>")+9:text_extra.find("</geojson>")]
+                        extra_str = extra_str[extra_str.find("<geojson>")+9:extra_str.find("</geojson>")]
+                        
+                        #prints the extra string to the log
                         QgsMessageLog.logMessage("Extra String: %s" % extra_str, 'LiteratureMapper', Qgis.Info)
+                        
+                        
                         check_point = '"type": "Point"'
                         check_multipoint = '"type": "Multip'
                         if extra_str[1:16] == check_point:

--- a/literature_mapper.py
+++ b/literature_mapper.py
@@ -250,7 +250,7 @@ class LiteratureMapper:
             extraZotero = item_json['data']['extra']
             before_geojson = extraZotero[0 : extraZotero.find("<geojson>")]
             after_geojson = extraZotero[extraZotero.find("</geojson>")+10:]
-            extraString = '%s "<geojson>" %s "</geojson>" %s' % (before_geojson, tablegeom, after_geojson) #build the new extraString here
+            extraString = '%s<geojson>%s</geojson>%s' % (before_geojson, tablegeom, after_geojson) #build the new extraString here
             
             QgsMessageLog.logMessage("row: %s  itemKey: %s  extraString: %s" % (row, itemKey, extraString), 'LiteratureMapper', Qgis.Info)
             
@@ -509,17 +509,15 @@ class LiteratureMapper:
                         
                         #example of how to pull out the geojson string from a messy Extra field:
                         #geojson_str = text_extra[text_extra.find("<geojson>")+9:text_extra.find("</geojson>")]
-                        
-                     
-                        
-                        
-                        if "<geojson>" in extra_zotero:
-                            extra_str = extra_zotero[extra_zotero.find("<geojson>")+9:extra_zotero.find("</geojson>")]
+                                         
+                                                
+                        if '<geojson>' in extra_zotero:
+                            extra_str = extra_zotero[extra_zotero.find('<geojson>')+9:extra_zotero.find('</geojson>')]
                             #before_geojson = extra_zotero[0 : extra_zotero.find("<geojson>")]
                             #after_geojson = extra_zotero[extra_zotero.find("</geojson>")+10:]
-                        elif "{\"type\":" in extra_zotero:
-                            extra_str = extra_zotero[extra_zotero.find("{"):extra_zotero.find("}")]
-                        else: extra_str = ""
+                        elif '{"type":' in extra_zotero:
+                            extra_str = extra_zotero[extra_zotero.find('{'):extra_zotero.find('}')]
+                        else: extra_str = ''
                         
                         extra = QTableWidgetItem(extra_str)
                         
@@ -570,6 +568,7 @@ class LiteratureMapper:
                             self.multipointLayer.updateExtents()
                         else:
                             x = ''
+                            QgsMessageLog.logMessage("Not a point or multipoint", 'LiteratureMapper', Qgis.Info)
                     else:
                         extra = QTableWidgetItem("")
                     self.dlgTable.tableWidget_Zotero.setItem(i, 4, extra)


### PR DESCRIPTION
This branch solves the problem of Literature Mapper deleting text users have stored in the Extra field of their Zotero records.  It will look for the geojson string and upon saving, wrap it in a html-style tag for easy finding later, all while saving the existing text.